### PR TITLE
feat: biome extension 설치 권장 및 defaultFormatter 추가

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["biome.biome", "biomejs.biome"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,11 @@
   "files.eol": "\n",
   "files.trimTrailingWhitespace": true,
   "editor.formatOnSave": true,
-  "editor.formatOnType": true
+  "editor.formatOnType": true,
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
 }


### PR DESCRIPTION
## 변경 사항 요약

biome extension 설치 권장 및 defaultFormatter 설정

## 변경 사유

biome를 저장할 때마다 사용하려면 biome extension과 defaultFormatter 설정이 필요합니다.