### PR TITLE
feat: scroll-progress-bar 컴포넌트 추가

### DIFF
--- a/src/pages/Test/test.page.tsx
+++ b/src/pages/Test/test.page.tsx
@@ -1,13 +1,15 @@
-import { PostTitle } from "@/src/entities/posts/ui/post-title";
+import { ProgrresBar } from "@/src/shared/common-ui/progress-bar";
 
 const TestPage = () => {
-	const testTitle = "“충격·경악·이럴수가…” 낚시질 제목 1등 언론은?";
-
 	return (
 		<>
+			<ProgrresBar />
 			<p className="text-seo-200 font-regular text-sm w-1/2 xs:bg-sky-300 sm:bg-seo-500 md:bg-red-400 lg:bg-white xl:bg-yellow-200">
 				tailwind 설정 테스트
 			</p>
+			<div className="bg-seo-300 h-screen"> </div>
+			<div className="bg-seo-300 h-screen"> </div>
+			<div className="bg-seo-300 h-screen"> </div>
 		</>
 	);
 };

--- a/src/shared/common-ui/progress-bar/index.ts
+++ b/src/shared/common-ui/progress-bar/index.ts
@@ -1,0 +1,1 @@
+export * from "./progress-bar";

--- a/src/shared/common-ui/progress-bar/progress-bar.tsx
+++ b/src/shared/common-ui/progress-bar/progress-bar.tsx
@@ -5,5 +5,11 @@ import { useScrollYPercent } from "@/src/shared/hooks/use-scroll-y-percent";
 export const ProgrresBar = () => {
 	const scrollYPercent = useScrollYPercent();
 
-	return <div className="fixed">{scrollYPercent}</div>;
+	return (
+		<div className="fixed w-full bg-seo-200 h-2.5">
+			<div className="bg-seo-600 h-2.5" style={{ width: `${scrollYPercent}%` }}>
+				{""}
+			</div>
+		</div>
+	);
 };

--- a/src/shared/common-ui/progress-bar/progress-bar.tsx
+++ b/src/shared/common-ui/progress-bar/progress-bar.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { useScrollYPercent } from "@/src/shared/hooks/use-scroll-y-percent";
+
+export const ProgrresBar = () => {
+	const scrollYPercent = useScrollYPercent();
+
+	return <div className="fixed">{scrollYPercent}</div>;
+};

--- a/src/shared/hooks/use-scroll-y-percent/index.ts
+++ b/src/shared/hooks/use-scroll-y-percent/index.ts
@@ -1,0 +1,2 @@
+import { useScrollYPercent } from "./use-scroll-y-percent";
+export { useScrollYPercent };

--- a/src/shared/hooks/use-scroll-y-percent/use-scroll-y-percent.ts
+++ b/src/shared/hooks/use-scroll-y-percent/use-scroll-y-percent.ts
@@ -5,20 +5,31 @@ import { throttle } from "../../utils/throttle";
 const THROTTLE_LIMIT = 50;
 
 export const useScrollYPercent = () => {
-	const [scrollYPercent, setScrollYPercent] = useState(0);
+	const [scrollYPercent, setScrollYPercent] = useState<number>(0);
 
 	useEffect(() => {
-		const totalHeight =
-			document.documentElement.scrollHeight - window.innerHeight;
-
-		const handleScroll = () => {
+		const calculateScrollPercentage = () => {
+			const totalHeight =
+				document.documentElement.scrollHeight - window.innerHeight;
 			setScrollYPercent((window.scrollY / totalHeight) * 100);
 		};
 
-		const throttleHandleScroll = throttle(handleScroll, THROTTLE_LIMIT);
+		const handleScroll = throttle(() => {
+			calculateScrollPercentage();
+		}, THROTTLE_LIMIT);
 
-		window.addEventListener("scroll", throttleHandleScroll);
-		return () => window.removeEventListener("scroll", throttleHandleScroll);
+		const handleResize = () => {
+			calculateScrollPercentage();
+		};
+		calculateScrollPercentage();
+
+		window.addEventListener("scroll", handleScroll);
+		window.addEventListener("resize", handleResize);
+
+		return () => {
+			window.removeEventListener("scroll", handleScroll);
+			window.removeEventListener("resize", handleResize);
+		};
 	}, []);
 
 	return scrollYPercent;

--- a/src/shared/hooks/use-scroll-y-percent/use-scroll-y-percent.ts
+++ b/src/shared/hooks/use-scroll-y-percent/use-scroll-y-percent.ts
@@ -1,0 +1,25 @@
+"use client";
+import { useEffect, useState } from "react";
+import { throttle } from "../../utils/throttle";
+
+const THROTTLE_LIMIT = 50;
+
+export const useScrollYPercent = () => {
+	const [scrollYPercent, setScrollYPercent] = useState(0);
+
+	useEffect(() => {
+		const totalHeight =
+			document.documentElement.scrollHeight - window.innerHeight;
+
+		const handleScroll = () => {
+			setScrollYPercent((window.scrollY / totalHeight) * 100);
+		};
+
+		const throttleHandleScroll = throttle(handleScroll, THROTTLE_LIMIT);
+
+		window.addEventListener("scroll", throttleHandleScroll);
+		return () => window.removeEventListener("scroll", throttleHandleScroll);
+	}, []);
+
+	return scrollYPercent;
+};

--- a/src/shared/hooks/use-scroll-y-percent/use-scroll-y-percent.ts
+++ b/src/shared/hooks/use-scroll-y-percent/use-scroll-y-percent.ts
@@ -1,8 +1,10 @@
 "use client";
 import { useEffect, useState } from "react";
 import { throttle } from "../../utils/throttle";
+import { debounce } from "../../utils/debounce";
 
 const THROTTLE_LIMIT = 50;
+const DEBOUNCE_LIMIT = 100;
 
 export const useScrollYPercent = () => {
 	const [scrollYPercent, setScrollYPercent] = useState<number>(0);
@@ -18,9 +20,10 @@ export const useScrollYPercent = () => {
 			calculateScrollPercentage();
 		}, THROTTLE_LIMIT);
 
-		const handleResize = () => {
+		const handleResize = debounce(() => {
 			calculateScrollPercentage();
-		};
+		}, DEBOUNCE_LIMIT);
+
 		calculateScrollPercentage();
 
 		window.addEventListener("scroll", handleScroll);

--- a/src/shared/utils/debounce/debounce.ts
+++ b/src/shared/utils/debounce/debounce.ts
@@ -1,0 +1,12 @@
+export function debounce<T extends unknown[]>(
+	callback: (...params: T) => void,
+	limit = 300,
+): (...params: T) => void {
+	let timer: ReturnType<typeof setTimeout>;
+	return (...params: T) => {
+		clearTimeout(timer);
+		timer = setTimeout(() => {
+			callback(...params);
+		}, limit);
+	};
+}

--- a/src/shared/utils/debounce/index.ts
+++ b/src/shared/utils/debounce/index.ts
@@ -1,0 +1,2 @@
+import { debounce } from "./debounce";
+export { debounce };


### PR DESCRIPTION
# PR 제목

## 변경 사항 요약

1. scroll-progress-bar 컴포넌트 추가
2. useScrollYPercent 훅 추가
3. useScrollYPercent 훅 화면 리사이징 대응
4. debounce 유틸 함수 추가
5. useScrollYPercent 훅 리사이징에 debounce 적용

## 변경 사유

## 변경 내용

### useScrollYPercent 훅 추가
- 스크롤의 위치를 백분율로 알려주는 훅 추가
###  useScrollYPercent 훅 화면 리사이징 대응
- 화면 리사이즈에 맞춰 스크롤 위치를 다시 대응하도록 구현
### debounce 유틸 함수 추가 & useScrollYPercent 훅 리사이징에 debounce 적용
- 리사이즈 이벤트의 발생빈도 조절을 위해 debounce 적용


## 사용 방법

<!-- 이 변경 사항을 어떻게 사용하는지 설명해주세요. 필요한 경우 코드 블록을 사용하여 예시를 보여주세요. -->

## 테스트 방법

<!-- 이 변경 사항을 어떻게 테스트했는지 설명해주세요. -->

## 추가 정보

<!-- 이 PR과 관련된 추가 정보가 있다면 여기에 기술해주세요. -->

## 스크린샷

![image](https://github.com/nakjun12/seo-blog/assets/97648143/7a756c04-53c6-4965-975c-f0dd0bc30877)
![image](https://github.com/nakjun12/seo-blog/assets/97648143/9ffce446-10de-413a-9238-aaf974270663)


