### PR TITLE
[fix] 브레드크럼 json-LD 수정

### DIFF
--- a/app/(posts)/posts/page.tsx
+++ b/app/(posts)/posts/page.tsx
@@ -4,12 +4,20 @@ import { createPostsMetaData } from "@/src/entities/posts/lib/utils/post.util";
 import { getAllPosts } from "@/src/entities/posts/model/post";
 import { redirect } from "next/navigation";
 import type { Metadata } from "next/types";
+import Head from "next/head";
 
 export default async function Posts() {
 	const posts = await getAllPosts();
 	if (!posts) return redirect("/");
 
-	return <PostsPage posts={posts} />;
+	return (
+		<>
+			<Head>
+				<meta name="123" content="인덱스 페이지입니다." />
+			</Head>
+			<PostsPage posts={posts} />
+		</>
+	);
 }
 
 export const generateMetadata = async (): Promise<Metadata> => {

--- a/src/shared/common-ui/breadcrumb/breadcrumb.tsx
+++ b/src/shared/common-ui/breadcrumb/breadcrumb.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Fragment } from "react";
 import { Routes } from "../../routes";
-import Head from "next/head";
+import Script from "next/script";
 
 interface BreadcrumbItem {
 	label: string;
@@ -51,13 +51,11 @@ export const Breadcrumb = () => {
 
 	return (
 		<>
-			<Head>
-				<script
-					type="application/ld+json"
-					// biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
-					dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
-				/>
-			</Head>
+			<Script
+				type="application/ld+json"
+				// biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+			/>
 			<div
 				className="flex space-x-1 text-seo-500 text-1618 my-4"
 				aria-label="breadcrumb"
@@ -66,7 +64,11 @@ export const Breadcrumb = () => {
 					<Fragment key={url}>
 						<Link
 							href={url}
-							className={isLast ? "font-bold text-seo-600" : ""}
+							className={` ${
+								isLast
+									? "font-bold text-seo-600"
+									: "hover:underline hover:underline-offset-4"
+							}`}
 							title={label}
 							onClick={isLast ? (e) => e.preventDefault() : undefined}
 						>


### PR DESCRIPTION
# [fix] 브레드크럼 json-LD 수정

## 변경 사항 요약

1. 브레드크럼 json-LD 수정

## 변경 사유

기존 적용했던 `next/head` 컴포넌트가 pages 라우터에서 적용되던 것이라 app 라우터용인  `next/script` 컴포넌트로 변경

## 변경 내용

`next/head` 컴포넌트에서  `next/script` 컴포넌트로 변경

## 사용 방법

<!-- 이 변경 사항을 어떻게 사용하는지 설명해주세요. 필요한 경우 코드 블록을 사용하여 예시를 보여주세요. -->

## 테스트 방법

<!-- 이 변경 사항을 어떻게 테스트했는지 설명해주세요. -->

## 추가 정보

<!-- 이 PR과 관련된 추가 정보가 있다면 여기에 기술해주세요. -->

## 스크린샷

![image](https://github.com/nakjun12/seo-blog/assets/97648143/1857fd1f-6bdb-460a-9997-8fdac539476f)
