### PR TITLE
[fix] 브레드크럼 json-LD url 절대 경로로 수정

### DIFF
--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -1,5 +1,0 @@
-import TestPage from "@/src/_pages/Test/test.page";
-
-export default async function Test() {
-	return <TestPage />;
-}

--- a/src/_pages/Test/test.page.tsx
+++ b/src/_pages/Test/test.page.tsx
@@ -1,5 +1,0 @@
-const TestPage = () => {
-	return <></>;
-};
-
-export default TestPage;

--- a/src/shared/common-ui/breadcrumb/breadcrumb.tsx
+++ b/src/shared/common-ui/breadcrumb/breadcrumb.tsx
@@ -3,8 +3,9 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Fragment } from "react";
-import { Routes } from "../../routes";
+import { Routes } from "@/src/shared/routes";
 import Script from "next/script";
+import { BASE_URL } from "@/src/shared/config/constant";
 
 interface BreadcrumbItem {
 	label: string;
@@ -24,7 +25,7 @@ const generateBreadcrumbs = (): BreadcrumbItem[] => {
 
 	return [
 		{
-			label: "Home",
+			label: "home",
 			url: Routes.home.path(),
 			isLast: breadcrumbs.length === 0,
 		},
@@ -40,7 +41,7 @@ const generateBreadcrumbJsonLd = (breadcrumbs: BreadcrumbItem[]) => {
 			"@type": "ListItem",
 			position: index + 1,
 			name: breadcrumb.label,
-			item: breadcrumb.url,
+			item: `${BASE_URL}/${breadcrumb.url}`,
 		})),
 	};
 };


### PR DESCRIPTION
# [fix] 브레드크럼 json-LD url 절대 경로로 수정

## 변경 사항 요약

1. 브레드크럼 json-LD url 절대 경로로 수정


## 변경 사유

![image](https://github.com/nakjun12/seo-blog/assets/97648143/29d063cd-2730-4d42-ae53-b89938cb6af1)
json-ld의 url이 상대 경로로 작성되어 변경

## 변경 내용

 json-LD url 상대경로에서  절대경로로 수정

## 사용 방법

<!-- 이 변경 사항을 어떻게 사용하는지 설명해주세요. 필요한 경우 코드 블록을 사용하여 예시를 보여주세요. -->

## 테스트 방법

<!-- 이 변경 사항을 어떻게 테스트했는지 설명해주세요. -->

## 추가 정보

<!-- 이 PR과 관련된 추가 정보가 있다면 여기에 기술해주세요. -->

## 스크린샷

<!-- UI 변경 사항이 있다면 스크린샷을 첨부해주세요. -->
