### PR TITLE
[fix] 브레드크럼 json-LD url 경로 수정

### DIFF
--- a/src/shared/common-ui/breadcrumb/breadcrumb.tsx
+++ b/src/shared/common-ui/breadcrumb/breadcrumb.tsx
@@ -41,7 +41,7 @@ const generateBreadcrumbJsonLd = (breadcrumbs: BreadcrumbItem[]) => {
 			"@type": "ListItem",
 			position: index + 1,
 			name: breadcrumb.label,
-			item: `${BASE_URL}/${breadcrumb.url}`,
+			item: BASE_URL + breadcrumb.url,
 		})),
 	};
 };


### PR DESCRIPTION
# [fix] 브레드크럼 json-LD url 경로 수정

## 변경 사항 요약

1. 브레드크럼 json-LD url 경로 수정

## 변경 사유

브레드크럼 json-LD url 경로에 `/`가 중복됨

## 변경 내용

브레드크럼 json-LD url 경로에 `/`가 중복제거

## 사용 방법

<!-- 이 변경 사항을 어떻게 사용하는지 설명해주세요. 필요한 경우 코드 블록을 사용하여 예시를 보여주세요. -->

## 테스트 방법

<!-- 이 변경 사항을 어떻게 테스트했는지 설명해주세요. -->

## 추가 정보

<!-- 이 PR과 관련된 추가 정보가 있다면 여기에 기술해주세요. -->

## 스크린샷

![image](https://github.com/nakjun12/seo-blog/assets/97648143/07e5cba7-ba4b-45ca-9900-52b2a255276e)
