### PR TITLE
[feat] desktop category 추가desktop category 추가

### DIFF
--- a/src/_pages/home/home.page.tsx
+++ b/src/_pages/home/home.page.tsx
@@ -1,7 +1,6 @@
 import type { Frontmatter, Post } from "@/src/entities/posts/model/post.type";
 import { PostCardList } from "@/src/entities/posts/ui/post-card-list";
 import { PostTitle } from "@/src/entities/posts/ui/post-title";
-import Link from "next/link";
 
 interface HomeProps {
 	posts: (Post & Frontmatter)[];
@@ -10,25 +9,8 @@ interface HomeProps {
 const HomePage = ({ posts }: HomeProps) => {
 	return (
 		<main className="px-4 mx-auto lg:max-w-6xl">
-			<PostTitle title="🚧공사 중🚧" />
 			<br />
-			<p className="text-2640">카테고리</p>
-			<div className="flex gap-2 p-0">
-				<Link
-					href="/react"
-					title="react 카테고리"
-					className="text-1830 bg-seo-500 hover:bg-seo-400 text-white font-bold py-1 px-4 rounded"
-				>
-					react
-				</Link>
-				<Link
-					href="/next"
-					title="next 카테고리"
-					className="text-1830 bg-seo-500 hover:bg-seo-400 text-white font-bold py-1 px-4 rounded"
-				>
-					next
-				</Link>
-			</div>
+			<PostTitle title="All Posts" />
 			<br />
 			<PostCardList posts={posts} />
 		</main>

--- a/src/feature/desktop-category/desktop-category.tsx
+++ b/src/feature/desktop-category/desktop-category.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect } from "react";
 
-export const MobileCategory = ({ categories }: { categories: string[] }) => {
+export const DesktopCategory = ({ categories }: { categories: string[] }) => {
 	const { isMenuOpen, toggleMenu } = useToggleStore();
 	const pathname = usePathname().replace(/\//g, "");
 
@@ -30,7 +30,7 @@ export const MobileCategory = ({ categories }: { categories: string[] }) => {
 	}, [isMenuOpen, toggleMenu]);
 
 	return (
-		<menu className="absolute top-12 left-0 w-full bg-white shadow-lg z-50 lg:hidden  h-screen overflow-y-auto p-6 flex flex-col gap-6">
+		<menu className="absolute top-[48px] left-[80px] h-14 bg-white shadow-xl z-50 p-6 flex gap-6 rounded-md border border-seo-200 items-center">
 			{categories.map((category) => (
 				<Link
 					href={`/${category}`}
@@ -43,10 +43,10 @@ export const MobileCategory = ({ categories }: { categories: string[] }) => {
 							toggleMenu(false);
 						}
 					}}
-					className={`text-1818   ${
+					className={`text-1418 rounded-md p-2 ${
 						pathname === category
-							? "text-seo-600 font-medium"
-							: "text-seo-400 font-normal hover:text-seo-500"
+							? "text-seo-600 font-bold"
+							: "text-seo-500 font-normal hover:bg-seo-200 hover:font-medium"
 					}`}
 				>
 					{capitalizeFirstLetter(category)}

--- a/src/feature/desktop-category/index.ts
+++ b/src/feature/desktop-category/index.ts
@@ -1,0 +1,1 @@
+export * from "./desktop-category";

--- a/src/feature/index.ts
+++ b/src/feature/index.ts
@@ -1,2 +1,3 @@
 export * from "./mobile-category";
 export * from "./open-menu";
+export * from "./open-category";

--- a/src/feature/open-category/index.ts
+++ b/src/feature/open-category/index.ts
@@ -1,0 +1,1 @@
+export * from "./open-category";

--- a/src/feature/open-category/open-category.tsx
+++ b/src/feature/open-category/open-category.tsx
@@ -1,14 +1,22 @@
 "use client";
-import useToggleStore from "@/src/shared/stores/toggle-menu";
 
-export const OpenCategory = () => {
+import { useOutsideClick } from "@/src/shared/hooks/use-outside-click";
+import useToggleStore from "@/src/shared/stores/toggle-menu";
+import { useRef } from "react";
+import { DesktopCategory } from "../desktop-category";
+
+export const OpenCategory = ({ categories }: { categories: string[] }) => {
 	const { isMenuOpen, toggleMenu } = useToggleStore();
+	const catgoryRef = useRef(null);
+
 	const handleMenuClick = () => {
 		toggleMenu(!isMenuOpen);
 	};
 
+	useOutsideClick(catgoryRef, () => toggleMenu(false));
+
 	return (
-		<div className="hidden lg:block">
+		<div ref={catgoryRef}>
 			<button
 				type="button"
 				onClick={handleMenuClick}
@@ -38,6 +46,7 @@ export const OpenCategory = () => {
 					/>
 				</div>
 			</button>
+			{isMenuOpen && <DesktopCategory categories={categories} />}
 		</div>
 	);
 };

--- a/src/feature/open-category/open-category.tsx
+++ b/src/feature/open-category/open-category.tsx
@@ -1,0 +1,43 @@
+"use client";
+import useToggleStore from "@/src/shared/stores/toggle-menu";
+
+export const OpenCategory = () => {
+	const { isMenuOpen, toggleMenu } = useToggleStore();
+	const handleMenuClick = () => {
+		toggleMenu(!isMenuOpen);
+	};
+
+	return (
+		<div className="hidden lg:block">
+			<button
+				type="button"
+				onClick={handleMenuClick}
+				className={`flex items-center gap-0.5 px-3 py-1.5 ${
+					isMenuOpen && "bg-seo-200 rounded-md"
+				}`}
+			>
+				<div
+					className={`text-1422 font-medium ${
+						isMenuOpen ? "text-seo-600" : "text-seo-500"
+					}`}
+				>
+					카테고리
+				</div>
+				<div className="flex justify-center items-center">
+					<span
+						className={`transition-all duration-300 ease-out translate-x-[0.2rem]
+        h-0.5 w-2 rounded-md ${
+					isMenuOpen ? "-rotate-45 bg-seo-600" : "rotate-45 bg-seo-500"
+				}`}
+					/>
+					<span
+						className={`transition-all duration-300 ease-out translate-x--[0.2rem]
+        h-0.5 w-2 rounded-md ${
+					isMenuOpen ? "rotate-45 bg-seo-600" : "-rotate-45 bg-seo-500"
+				}`}
+					/>
+				</div>
+			</button>
+		</div>
+	);
+};

--- a/src/feature/open-menu/open-menu.tsx
+++ b/src/feature/open-menu/open-menu.tsx
@@ -10,7 +10,7 @@ export const OpenMenu = () => {
 		<button
 			type="button"
 			onClick={handleMenuClick}
-			className="flex flex-col justify-center items-center lg:hidden"
+			className="flex flex-col justify-center items-center"
 		>
 			<span
 				className={`bg-seo-600   transition-all duration-300 ease-out

--- a/src/shared/hooks/use-outside-click/index.ts
+++ b/src/shared/hooks/use-outside-click/index.ts
@@ -1,0 +1,2 @@
+import { useOutsideClick } from "./use-outside-click";
+export { useOutsideClick };

--- a/src/shared/hooks/use-outside-click/use-outside-click.ts
+++ b/src/shared/hooks/use-outside-click/use-outside-click.ts
@@ -1,0 +1,27 @@
+import { type RefObject, useCallback, useEffect } from "react";
+
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+const useOutsideClick = (ref: RefObject<any>, callback: () => void) => {
+	const runCallback = useCallback(
+		({ target }: MouseEvent | TouchEvent) => {
+			if (target === null) {
+				return;
+			}
+
+			if (ref.current && !ref.current.contains(target as HTMLDivElement)) {
+				callback();
+			}
+		},
+		[ref, callback],
+	);
+
+	useEffect(() => {
+		window.addEventListener("click", runCallback);
+
+		return () => {
+			window.removeEventListener("click", runCallback);
+		};
+	}, [runCallback]);
+};
+
+export default useOutsideClick;

--- a/src/shared/hooks/use-outside-click/use-outside-click.ts
+++ b/src/shared/hooks/use-outside-click/use-outside-click.ts
@@ -1,7 +1,7 @@
 import { type RefObject, useCallback, useEffect } from "react";
 
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-const useOutsideClick = (ref: RefObject<any>, callback: () => void) => {
+export const useOutsideClick = (ref: RefObject<any>, callback: () => void) => {
 	const runCallback = useCallback(
 		({ target }: MouseEvent | TouchEvent) => {
 			if (target === null) {
@@ -23,5 +23,3 @@ const useOutsideClick = (ref: RefObject<any>, callback: () => void) => {
 		};
 	}, [runCallback]);
 };
-
-export default useOutsideClick;

--- a/src/widgets/header/header.tsx
+++ b/src/widgets/header/header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MobileCategory, OpenMenu } from "@/src/feature";
+import { MobileCategory, OpenCategory, OpenMenu } from "@/src/feature";
 import { ProgressBar } from "@/src/shared/common-ui/progress-bar";
 import { useScrollDirection } from "@/src/shared/hooks/use-scroll-direction";
 import useToggleStore from "@/src/shared/stores/toggle-menu";
@@ -27,7 +27,7 @@ export const Header = ({ categories }: { categories: string[] }) => {
 		<header className="top-0 z-50 mx-auto lg:max-w-6xl h-[50px] sticky">
 			<nav>
 				<div
-					className={`h-full p-2.5 border-b bg-seo-100 flex justify-between lg:justify-start lg:gap-2 transition-transform duration-300 ease-in-out ${
+					className={`h-full p-2 border-b bg-seo-100 flex justify-between items-center lg:justify-start lg:gap-3 transition-transform duration-300 ease-in-out ${
 						isNav
 							? "transform-none opacity-100"
 							: "transform -translate-y-full opacity-0"
@@ -46,7 +46,7 @@ export const Header = ({ categories }: { categories: string[] }) => {
 						DevDive
 					</Link>
 					<OpenMenu />
-					<div className="hidden lg:block">카테고리</div>
+					<OpenCategory />
 					{isMenuOpen && <MobileCategory categories={categories} />}
 				</div>
 				{depth === 3 && !isNav && <ProgressBar />}

--- a/src/widgets/header/header.tsx
+++ b/src/widgets/header/header.tsx
@@ -12,19 +12,29 @@ export const Header = ({ categories }: { categories: string[] }) => {
 	const scrollDirection = useScrollDirection();
 	const { isMenuOpen } = useToggleStore();
 	const [isNav, setIsNav] = useState(true);
+	const [isDesktop, setIsDesktop] = useState(
+		typeof window !== "undefined" && 1064 <= window.innerWidth,
+	);
 	const path = usePathname();
 	const depth = path.split("/").length;
 
 	useEffect(() => {
+		const handleResize = () => {
+			setIsDesktop(1064 <= window.innerWidth);
+		};
+
 		if (scrollDirection === "up") {
 			setIsNav(true);
 		} else {
 			setIsNav(false);
 		}
+
+		window.addEventListener("resize", handleResize);
+		return () => window.removeEventListener("resize", handleResize);
 	}, [scrollDirection]);
 
 	return (
-		<header className="top-0 z-50 mx-auto lg:max-w-6xl h-[50px] sticky">
+		<header className="top-0 z-50 mx-auto lg:max-w-6xl h-[50px] sticky min-h-[]">
 			<nav>
 				<div
 					className={`h-full p-2 border-b bg-seo-100 flex justify-between items-center lg:justify-start lg:gap-3 transition-transform duration-300 ease-in-out ${
@@ -36,7 +46,7 @@ export const Header = ({ categories }: { categories: string[] }) => {
 					<Link
 						href="/"
 						title="DevDive"
-						className="text-1218 text-seo-100 bg-seo-600 rounded-full px-2 py-1.5"
+						className="text-1218 text-seo-100 bg-seo-600 rounded-full px-2 py-1.5 my-0.5"
 						onClick={(e) => {
 							if (path === "/") {
 								e.preventDefault();
@@ -45,9 +55,14 @@ export const Header = ({ categories }: { categories: string[] }) => {
 					>
 						DevDive
 					</Link>
-					<OpenMenu />
-					<OpenCategory />
-					{isMenuOpen && <MobileCategory categories={categories} />}
+					{isDesktop ? (
+						<OpenCategory categories={categories} />
+					) : (
+						<>
+							<OpenMenu />
+							{isMenuOpen && <MobileCategory categories={categories} />}
+						</>
+					)}
 				</div>
 				{depth === 3 && !isNav && <ProgressBar />}
 			</nav>


### PR DESCRIPTION
# [feat] desktop category 추가

## 변경 사항 요약

1. open-category 버튼 추가
2. useOutsideClick 훅 추가
3. desktop category 추가


## 변경 사유

### useOutsideClick 훅 추가
- 카테고리 모달 바깥을 클릭하면 닫기위해 훅 추가

## 변경 내용

- open-category 버튼 추가
- useOutsideClick 훅 추가
- desktop category 추가

## 사용 방법

<!-- 이 변경 사항을 어떻게 사용하는지 설명해주세요. 필요한 경우 코드 블록을 사용하여 예시를 보여주세요. -->

## 테스트 방법

<!-- 이 변경 사항을 어떻게 테스트했는지 설명해주세요. -->

## 추가 정보

<!-- 이 PR과 관련된 추가 정보가 있다면 여기에 기술해주세요. -->

## 스크린샷

![image](https://github.com/nakjun12/seo-blog/assets/97648143/fd8c916a-2b4c-49af-9684-6cd53cd4e16d)
![image](https://github.com/nakjun12/seo-blog/assets/97648143/edf4ff62-4ca5-49c5-8025-6fa6d39b31fe)

