### PR TITLE
[fix] desktop category 스크롤 금지 수정

### DIFF
--- a/src/feature/desktop-category/desktop-category.tsx
+++ b/src/feature/desktop-category/desktop-category.tsx
@@ -4,30 +4,10 @@ import { capitalizeFirstLetter } from "@/src/entities/posts/lib/utils/language.u
 import useToggleStore from "@/src/shared/stores/toggle-menu";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect } from "react";
 
 export const DesktopCategory = ({ categories }: { categories: string[] }) => {
-	const { isMenuOpen, toggleMenu } = useToggleStore();
+	const { toggleMenu } = useToggleStore();
 	const pathname = usePathname().replace(/\//g, "");
-
-	useEffect(() => {
-		const handleResize = () => {
-			toggleMenu(false);
-		};
-
-		window.addEventListener("resize", handleResize);
-
-		if (isMenuOpen) {
-			document.body.style.overflow = "hidden";
-		} else {
-			document.body.style.overflow = "";
-		}
-
-		return () => {
-			window.removeEventListener("resize", handleResize);
-			document.body.style.overflow = "";
-		};
-	}, [isMenuOpen, toggleMenu]);
 
 	return (
 		<menu className="absolute top-[48px] left-[80px] h-14 bg-white shadow-xl z-50 p-6 flex gap-6 rounded-md border border-seo-200 items-center">


### PR DESCRIPTION
# [fix] desktop category 스크롤 금지 수정

## 변경 사항 요약

1. desktop category 스크롤 금지 수정

## 변경 사유

- 햄버거 메뉴 레이아웃을 복사하다 로직도 같이 복사했는데 안지웠음

## 변경 내용

desktop category 스크롤 금지 수정

## 사용 방법

<!-- 이 변경 사항을 어떻게 사용하는지 설명해주세요. 필요한 경우 코드 블록을 사용하여 예시를 보여주세요. -->

## 테스트 방법

<!-- 이 변경 사항을 어떻게 테스트했는지 설명해주세요. -->

## 추가 정보

<!-- 이 PR과 관련된 추가 정보가 있다면 여기에 기술해주세요. -->

## 스크린샷

<!-- UI 변경 사항이 있다면 스크린샷을 첨부해주세요. -->
