### PR TITLE
[fix] robots.ts , sitemap.ts next 구성요소로 이동

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from "next";
-import { BASE_URL } from "../shared/config/constant";
+import { BASE_URL } from "../src/shared/config/constant";
 
 export default function robots(): MetadataRoute.Robots {
 	return {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
-import { getAllPosts } from "../entities/posts/model/post";
-import { BASE_URL } from "../shared/config/constant";
+import { getAllPosts } from "../src/entities/posts/model/post";
+import { BASE_URL } from "../src/shared/config/constant";
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	const baseUrl = BASE_URL;
 	const posts = await getAllPosts();


### PR DESCRIPTION
# PR 제목

## 변경 사항 요약

기존 구조에서는 robots.ts , sitemap.ts가 FSD의 app 폴더에 존재하여 관심사와 다르게 파일이 배치되는 문제가 있었음

해당 문제를 해결하기 위해 next.js의 App 폴더로 이동하며 동작은 기존과 같음

## 변경 사유

<!-- 이 변경이 왜 필요한지에 대한 배경을 설명해주세요. 관련 이슈가 있다면 링크를 추가해주세요. -->

## 변경 내용

<!-- 자세한 변경 내용을 기술해주세요. -->

- 변경 사항 1
- 변경 사항 2
- ...

## 사용 방법

<!-- 이 변경 사항을 어떻게 사용하는지 설명해주세요. 필요한 경우 코드 블록을 사용하여 예시를 보여주세요. -->

## 테스트 방법

<!-- 이 변경 사항을 어떻게 테스트했는지 설명해주세요. -->

## 추가 정보

<!-- 이 PR과 관련된 추가 정보가 있다면 여기에 기술해주세요. -->

## 스크린샷

<!-- UI 변경 사항이 있다면 스크린샷을 첨부해주세요. -->
