### PR TITLE
fix: isReleased 판단 오류 수정

### DIFF
--- a/src/entities/posts/lib/utils/post.util.ts
+++ b/src/entities/posts/lib/utils/post.util.ts
@@ -1,7 +1,7 @@
 import { BASE_URL, SITE_NAME } from "@/src/shared/config/constant";
-import dayjs from "dayjs";
 import type { Metadata } from "next/types";
 import type { Frontmatter } from "../../model/post.type";
+import { findOutIsReleased } from "./time.util";
 
 export const createMetaData = ({
 	url,
@@ -10,10 +10,7 @@ export const createMetaData = ({
 	url: string;
 	post: Frontmatter;
 }): Metadata => {
-	const today = dayjs(new Date().toISOString());
-	const isReleased =
-		today.isSame(post?.releaseDate, "day") &&
-		!today.isBefore(post?.releaseDate, "day");
+	const isReleased = findOutIsReleased(post.releaseDate);
 	return {
 		title: post.title,
 		description: post.description,

--- a/src/entities/posts/lib/utils/time.util.ts
+++ b/src/entities/posts/lib/utils/time.util.ts
@@ -17,7 +17,7 @@ export const isFirstDateBeforeSecond = (
 };
 
 export const findOutIsReleased = (postReleaseDate: string): boolean => {
-	const today = new Date();
-	const releaseDate = new Date(postReleaseDate);
-	return releaseDate < today;
+	const today = dayjs();
+	const releaseDate = dayjs(postReleaseDate);
+	return today.isSame(releaseDate) || today.isAfter(releaseDate);
 };

--- a/src/entities/posts/lib/utils/time.util.ts
+++ b/src/entities/posts/lib/utils/time.util.ts
@@ -15,3 +15,9 @@ export const isFirstDateBeforeSecond = (
 
 	return firstDate.isBefore(secondDate);
 };
+
+export const findOutIsReleased = (postReleaseDate: string): boolean => {
+	const today = new Date();
+	const releaseDate = new Date(postReleaseDate);
+	return releaseDate < today;
+};


### PR DESCRIPTION
# isReleased 판단 오류 수정

## 변경 사항 요약

- 메타 데이터를 생성하는 함수 내에서 isReleased의 true,false를 판단하는 로직을 수정하였습니다.

## 변경 사유

- 기존에 isReleased가 올바르게 적용되지 않아 index, noindex처리가 원하는 방식대로 이루어지고 있지 않았습니다.

## 변경 내용

1. `time.util.ts` 파일 내부로 `isReleased`를 판단하는 로직을 옮겼습니다.
```
export const findOutIsReleased = (postReleaseDate: string): boolean => {
	const today = dayjs();
	const releaseDate = dayjs(postReleaseDate);
	return today.isSame(releaseDate) || today.isAfter(releaseDate);
};
```
- 기존에 dayjs를 사용하여 today를 생성하는 부분에서 오류가 있었기에 해당 부분을 수정하였습니다.
- post의 releaseDate도 dayjs를 사용하여 비교하려면 Dayjs로 맞추어 주어야하기때문에 동일하게 생성해주었습니다.
- releaseDate가 오늘과 같거나 오늘이 releaseDate를 지난경우 isReleased가 true로 되도록 변경하였습니다.


## 사용 방법

- `post.util.ts` 파일내에서 import하여 사용가능합니다.
 ```
  import { findOutIsReleased } from "./time.util";
  export const createMetaData = ({
	url,
	post,
}: {
	url: string;
	post: Frontmatter;
}): Metadata => {
	const isReleased = findOutIsReleased(post.releaseDate);
```


## 테스트 방법

- 변경 후 블로그 포스팅을 조회하여 meta태그의 noindex, index가 release date에따라 적용되고 있는지 확인

## 추가 정보

<!-- 이 PR과 관련된 추가 정보가 있다면 여기에 기술해주세요. -->

## 스크린샷

<!-- UI 변경 사항이 있다면 스크린샷을 첨부해주세요. -->
